### PR TITLE
GKE max_pods_per_node in node configuration update examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ module "castai_gke_cluster" {
       tags           = {
         "node-config" : "default"
       }
-      max_pods_per_node = 110
+      gke = {
+        max_pods_per_node = 110
+      }
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -43,12 +43,13 @@ module "castai_gke_cluster" {
       tags           = {
         "node-config" : "default"
       }
+      max_pods_per_node = 110
     }
   }
 }
 ```
 
-[Example usage](https://github.com/castai/terraform-provider-castai/blob/master/examples/gke_cluster/main.tf)
+[Example usage](https://github.com/castai/terraform-provider-castai/tree/master/examples/gke)
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -78,6 +79,7 @@ No modules.
 | [castai_autoscaler.castai_autoscaler_policies](https://registry.terraform.io/providers/castai/castai/latest/docs/resources/autoscaler) | resource |
 | [castai_gke_cluster.castai_cluster](https://registry.terraform.io/providers/castai/castai/latest/docs/resources/gke_cluster) | resource |
 | [castai_node_configuration.this](https://registry.terraform.io/providers/castai/castai/latest/docs/resources/node_configuration) | resource |
+| [castai_node_configuration_default.this](https://registry.terraform.io/providers/castai/castai/latest/docs/resources/node_configuration_default) | resource |
 | [helm_release.castai_agent](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.castai_cluster_controller](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.castai_evictor](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -39,6 +39,9 @@ module "castai-gke-cluster" {
       tags           = {
         "node-config" : "default"
       }
+      gke = {
+        max_pods_per_node =110
+      }
     }
   }
 

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -39,7 +39,6 @@ module "castai-gke-cluster" {
       tags           = {
         "node-config" : "default"
       }
-      max_pods_per_node = 110
     }
   }
 

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -39,6 +39,7 @@ module "castai-gke-cluster" {
       tags           = {
         "node-config" : "default"
       }
+      max_pods_per_node = 110
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -11,12 +11,15 @@ resource "castai_node_configuration" "this" {
 
   cluster_id = castai_gke_cluster.castai_cluster.id
 
-  name           = try(each.value.name, each.key)
-  disk_cpu_ratio = try(each.value.disk_cpu_ratio, 0)
-  subnets        = try(each.value.subnets, null)
-  ssh_public_key = try(each.value.ssh_public_key, null)
-  image          = try(each.value.image, null)
-  tags           = try(each.value.tags, {})
+  name              = try(each.value.name, each.key)
+  disk_cpu_ratio    = try(each.value.disk_cpu_ratio, 0)
+  subnets           = try(each.value.subnets, null)
+  ssh_public_key    = try(each.value.ssh_public_key, null)
+  image             = try(each.value.image, null)
+  tags              = try(each.value.tags, {})
+  gke {
+    max_pods_per_node = try(each.value.max_pods_per_node, 110)
+  }
 }
 
 resource "castai_node_configuration_default" "this" {


### PR DESCRIPTION
- Added example with the new field
- Fixed a broken link to the main provider page, now points to the root of gke examples