### PR TITLE
Add artificial resource in order to wait for cluster to be in ready state

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -217,7 +217,7 @@ resource "null_resource" "wait_for_cluster" {
   provisioner "local-exec" {
     quiet = true
     environment = {
-      API_KEY = var.api_token
+      API_KEY = var.castai_api_token
     }
     command = <<-EOT
         RETRY_COUNT=20

--- a/main.tf
+++ b/main.tf
@@ -215,8 +215,21 @@ resource "null_resource" "wait_for_cluster" {
   depends_on = [helm_release.castai_cluster_controller, helm_release.castai_agent]
 
   provisioner "local-exec" {
+    quiet = true
+    environment = {
+      API_KEY = var.api_token
+    }
     command = <<-EOT
-        while ! curl ${var.api_url}/v1/kubernetes/external-clusters/${castai_gke_cluster.castai_cluster.id} -H "x-api-key: ${var.api_token}" | grep '"status"\s*:\s*"ready"'; do sleep 5; done
+        RETRY_COUNT=20
+        POOLING_INTERVAL=30
+
+        for i in $(seq 1 $RETRY_COUNT); do
+            sleep $POOLING_INTERVAL
+            curl -s ${var.api_url}/v1/kubernetes/external-clusters/${castai_gke_cluster.castai_cluster.id} -H "x-api-key: $API_KEY" | grep '"status"\s*:\s*"ready"' && exit 0
+        done
+
+        echo "Cluster is not ready after 10 minutes"
+        exit 1
     EOT
 
     interpreter = ["bash", "-c"]

--- a/variables.tf
+++ b/variables.tf
@@ -4,7 +4,7 @@ variable "api_url" {
   default     = "https://api.cast.ai"
 }
 
-variable "api_token" {
+variable "castai_api_token" {
   type = string
   description = "CAST AI API token created in console.cast.ai API Access keys section."
   sensitive = true

--- a/variables.tf
+++ b/variables.tf
@@ -6,8 +6,9 @@ variable "api_url" {
 
 variable "castai_api_token" {
   type = string
-  description = "CAST AI API token created in console.cast.ai API Access keys section."
+  description = "Optional CAST AI API token created in console.cast.ai API Access keys section. Used only when `wait_for_cluster_ready` is set to true"
   sensitive = true
+  default = ""
 }
 
 variable "project_id" {
@@ -105,5 +106,5 @@ variable "kvisor_values" {
 variable "wait_for_cluster_ready" {
   type        = bool
   description = "Wait for cluster to be ready before finishing the module execution"
-  default     = true
+  default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -105,6 +105,6 @@ variable "kvisor_values" {
 
 variable "wait_for_cluster_ready" {
   type        = bool
-  description = "Wait for cluster to be ready before finishing the module execution"
+  description = "Wait for cluster to be ready before finishing the module execution, this option requires `castai_api_token` to be set"
   default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "api_url" {
   default     = "https://api.cast.ai"
 }
 
+variable "api_token" {
+  type = string
+  description = "CAST AI API token created in console.cast.ai API Access keys section."
+  sensitive = true
+}
+
 variable "project_id" {
   type        = string
   description = "The project id from GCP"
@@ -94,4 +100,10 @@ variable "kvisor_values" {
   description = "List of YAML formatted string values for kvisor helm chart"
   type        = list(string)
   default     = []
+}
+
+variable "wait_for_cluster_ready" {
+  type        = bool
+  description = "Wait for cluster to be ready before finishing the module execution"
+  default     = true
 }


### PR DESCRIPTION

This commit introduces a change that will block module completion up until created cluster is in the `Ready` state.

Natural candidate for cluster ready state is `castai_gke_cluster` resource creation step. Hoverer as cluster resource needs to finish its creation in order to run helm charts that actually deploys components that makes cluster to transit to ready state we need to introduce custom resource that will depend on helm charts resources that will pool ready state.

To accomplish this `null_resource` was introduced that pools created cluster status until it is in ready state.