### PR TITLE
Fix castai provider version

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     castai = {
       source  = "castai/castai"
-      version = ">= 6.3.1"
+      version = ">= 6.3.0"
     }
     helm = {
       source  = "hashicorp/helm"


### PR DESCRIPTION
6.3.1 isnt availabile on the provider, which is causing this module to fail

```
Error: Failed to query available provider packages

Could not retrieve the list of available versions for provider castai/castai:
locked provider registry.terraform.io/castai/castai 6.3.0 does not match
configured version constraint >= 5.1.0, >= 6.3.1; must use terraform init
-upgrade to allow selection of new versions
