### PR TITLE
Add kubernetes as required provider

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -14,6 +14,10 @@ terraform {
       source  = "hashicorp/helm"
       version = ">= 2.0.0"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.0"
+    }
   }
 }
 


### PR DESCRIPTION
We get some warnings when using the cast.ai provider:

```
│ There is no explicit declaration for local provider name "kubernetes" in module.dev-castai, so Terraform is assuming you mean to pass a configuration for "hashicorp/kubernetes".
│
│ If you also control the child module, add a required_providers entry named "kubernetes" with the source address "hashicorp/kubernetes".
```
