### PR TITLE
fix: use node affinity objects instead of their keys when mapping

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -125,12 +125,12 @@ resource "castai_node_template" "this" {
           instance_types = try(dedicated_node_affinity.value.instance_types, [])
 
           dynamic "affinity" {
-            for_each = try(dedicated_node_affinity.value.affinity, {})
+            for_each = flatten([lookup(dedicated_node_affinity.value, "affinity", [])])
 
             content {
-              key      = try(affinity.key, null)
-              operator = try(affinity.operator, null)
-              values   = try(affinity.values, [])
+              key      = try(affinity.value.key, null)
+              operator = try(affinity.value.operator, null)
+              values   = try(affinity.value.values, [])
             }
           }
         }


### PR DESCRIPTION
Previously, when a user specified node affinities, for every provided node affinity we would try to map every _key_ to an "affinity" block. This produced invalid Terraform resources, because the values of the "key", "name" and "operator" keys on their own are not enough to create a valid "affinity" block.

This commit uses entire affinity objects and maps them to appropriate Terraform representations, fixing the problem.