### PR TITLE
docs: bump required CAST AI provider version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ Usage examples are located in [terraform provider repo](https://github.com/casta
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_castai"></a> [castai](#requirement\_castai) | ~> 7.11 |
+| <a name="requirement_castai"></a> [castai](#requirement\_castai) | ~> 7.14 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 2.49 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.0.0 |
 
@@ -308,7 +308,7 @@ Usage examples are located in [terraform provider repo](https://github.com/casta
 
 | Name | Version |
 |------|---------|
-| <a name="provider_castai"></a> [castai](#provider\_castai) | ~> 7.11 |
+| <a name="provider_castai"></a> [castai](#provider\_castai) | ~> 7.14 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.0.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | n/a |
 


### PR DESCRIPTION
I forgor to bump required provider version in #90 