### PR TITLE
LLM-554: Add optional deployment of AI-Optimiser

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,17 +320,17 @@ Usage examples are located in [terraform provider repo](https://github.com/casta
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_castai"></a> [castai](#requirement\_castai) | ~> 7.55 |
+| <a name="requirement_castai"></a> [castai](#requirement\_castai) | ~> 7.65 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 2.49 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_castai"></a> [castai](#provider\_castai) | 7.2.0 |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.13.2 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.2.2 |
+| <a name="provider_castai"></a> [castai](#provider\_castai) | ~> 7.65 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 3.0.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | n/a |
 
 ## Modules
 
@@ -347,6 +347,7 @@ No modules.
 | [castai_node_template.this](https://registry.terraform.io/providers/castai/castai/latest/docs/resources/node_template) | resource |
 | [castai_workload_scaling_policy.this](https://registry.terraform.io/providers/castai/castai/latest/docs/resources/workload_scaling_policy) | resource |
 | [helm_release.castai_agent](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [helm_release.castai_ai_optimizer_proxy](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.castai_cloud_proxy](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.castai_cluster_controller](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.castai_cluster_controller_self_managed](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
@@ -391,6 +392,7 @@ No modules.
 | <a name="input_gke_cluster_name"></a> [gke\_cluster\_name](#input\_gke\_cluster\_name) | Name of the cluster to be connected to CAST AI. | `string` | n/a | yes |
 | <a name="input_gke_credentials"></a> [gke\_credentials](#input\_gke\_credentials) | Optional GCP Service account credentials.json | `string` | n/a | yes |
 | <a name="input_grpc_url"></a> [grpc\_url](#input\_grpc\_url) | gRPC endpoint used by pod-pinner | `string` | `"grpc.cast.ai:443"` | no |
+| <a name="input_install_ai_optimizer"></a> [install\_ai\_optimizer](#input\_install\_ai\_optimizer) | Optional flag for installation of AI Optimizer (https://docs.cast.ai/docs/getting-started-ai) | `bool` | `false` | no |
 | <a name="input_install_cloud_proxy"></a> [install\_cloud\_proxy](#input\_install\_cloud\_proxy) | Optional flag for installation of castai-cloud-proxy | `bool` | `false` | no |
 | <a name="input_install_pod_mutator"></a> [install\_pod\_mutator](#input\_install\_pod\_mutator) | Optional flag for installation of pod mutator | `bool` | `false` | no |
 | <a name="input_install_security_agent"></a> [install\_security\_agent](#input\_install\_security\_agent) | Optional flag for installation of security agent (Kvisor - https://docs.cast.ai/docs/kvisor) | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -901,3 +901,29 @@ resource "castai_autoscaler" "castai_autoscaler_policies" {
 
   depends_on = [helm_release.castai_agent, helm_release.castai_evictor, helm_release.castai_pod_pinner]
 }
+
+resource "helm_release" "castai_ai_optimizer_proxy" {
+  count = var.install_ai_optimizer && !var.self_managed ? 1 : 0
+
+  name             = "ai-optimizer-proxy"
+  repository       = "https://castai.github.io/helm-charts"
+  chart            = "castai-ai-optimizer-proxy"
+  namespace        = "castai-agent"
+  create_namespace = true
+  cleanup_on_fail  = true
+  wait             = true
+
+  set = concat(
+    local.set_cluster_id,
+    local.set_apiurl,
+    local.set_pod_labels,
+  )
+
+  set_sensitive = local.set_sensitive_apikey
+
+  depends_on = [helm_release.castai_agent]
+
+  lifecycle {
+    ignore_changes = [version]
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -275,3 +275,9 @@ variable "organization_id" {
   type        = string
   default     = ""
 }
+
+variable "install_ai_optimizer" {
+  type        = bool
+  default     = false
+  description = "Optional flag for installation of AI Optimizer (https://docs.cast.ai/docs/getting-started-ai)"
+}


### PR DESCRIPTION
This PR adds an optional deployment of castai-ai-optimizer-proxy Helm chart. 
The deployment is controlled with a variable `install_ai_optimizer`.