### PR TITLE
feat: allow specifying Castware API URL

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,9 +1,12 @@
 locals {
+  # API URL used from within the cluster (by Castware) defaults to `api_url` but can be overwritten
+  castware_api_url = var.castware_api_url != "" ? var.castware_api_url : var.api_url
+
   # Common conditional non-sensitive values that we pass to helm_releases.
   # Set up as lists so they can be concatenated.
-  set_apiurl = var.api_url != "" ? [{
+  set_apiurl = local.castware_api_url != "" ? [{
     name  = "castai.apiURL"
-    value = var.api_url
+    value = local.castware_api_url
   }] : []
   set_cluster_id = [{
     name  = "castai.clusterID"

--- a/main.tf
+++ b/main.tf
@@ -248,9 +248,9 @@ resource "helm_release" "castai_agent" {
       }
     ],
     // castai-agent chart requires "apiURL" on the top level, NOT under "castai.apiURL"
-    var.api_url != "" ? [{
+    local.castware_api_url != "" ? [{
       name  = "apiURL"
-      value = var.api_url
+      value = local.castware_api_url
     }] : [],
     local.set_pod_labels,
   )

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "api_url" {
   default     = "https://api.cast.ai"
 }
 
+variable "castware_api_url" {
+  type        = string
+  description = "URL of CAST AI API to be used from within the cluster by Cast AI applications (Castware). If left empty, `api_url` will be used within the cluster."
+  default     = ""
+}
+
 variable "castai_api_token" {
   type        = string
   description = "Optional CAST AI API token created in console.cast.ai API Access keys section. Used only when `wait_for_cluster_ready` is set to true"


### PR DESCRIPTION
This is necessary to be able to differentiate between the API URL used by the Cast AI Terraform provider and the Castware components running in the cluster.

The motivation for different URLs comes from accessing the Cast AI API through GCP Private Service Connect. In that case the API URL accessed privately will contain a `.psc.` suffix, but that is only accessible via the private connections. Since Terraform will most probably not run with access to the private connection, it needs to be able to use the "usual" public URL, while setting up Castware components with the private URL.

## Proof of Work

I've successfully used the modified version of this module from [this example](https://github.com/castai/terraform-provider-castai/tree/master/examples/gke/gke_cluster_autoscaler_policies) to create a cluster behind PSC, see how the URL used when configuring the Helm charts is private:

<img width="644" height="276" alt="image" src="https://github.com/user-attachments/assets/b5ba8825-ce47-429f-b454-5beae459fd59" />

While the fact that Terraform was able to create the plan proves that it could access the public Cast AI through the public URL.

The cluster created this way was successfully onboarded (that relies on setting up the PSC connection beforehand, but I'm going to create another example about that, wouldn't want to pollute this module with that setup):

<img width="1541" height="474" alt="image" src="https://github.com/user-attachments/assets/183bcab3-e2f4-4f4d-939a-1e7117706016" />
