### PR TITLE
feat: add anomaly_detection support to workload scaling policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,13 @@ module "castai_gke_cluster" {
         }
       }
 
+      anomaly_detection = {
+        cpu_pressure = {
+          cpu_stall_threshold_percentage = 50
+          min_pressured_pod_percentage   = 30
+        }
+      }
+
       excluded_containers = ["container-1", "container-2"]
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -373,6 +373,19 @@ resource "castai_workload_scaling_policy" "this" {
       }
     }
   }
+
+  dynamic "anomaly_detection" {
+    for_each = try([each.value.anomaly_detection], [])
+    content {
+      dynamic "cpu_pressure" {
+        for_each = try([anomaly_detection.value.cpu_pressure], [])
+        content {
+          cpu_stall_threshold_percentage = try(cpu_pressure.value.cpu_stall_threshold_percentage, null)
+          min_pressured_pod_percentage   = try(cpu_pressure.value.min_pressured_pod_percentage, null)
+        }
+      }
+    }
+  }
 }
 
 resource "castai_workload_custom_metrics_data_source" "this" {


### PR DESCRIPTION
## Summary
- Adds `anomaly_detection` dynamic block to `castai_workload_scaling_policy` resource with nested `cpu_pressure` settings
- Updates README usage example with `anomaly_detection` configuration
- Bumps castai provider version to `>= 8.26.0`

Related provider PR: https://github.com/castai/terraform-provider-castai/pull/671